### PR TITLE
Line 4 throwing an error

### DIFF
--- a/packer/build.json
+++ b/packer/build.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "disk_size": "5000",
-    "memory": "2048m",
+    "memory": "2048M",
     "cpus": "2",
     "headless": "true",
     "iso_url": "https://cdimage.debian.org/mirror/cdimage/stretch_di_rc4/multi-arch/iso-cd/debian-stretch-DI-rc4-amd64-i386-netinst.iso",


### PR DESCRIPTION
I changed line 4 from `"memory": "2048m",` to `"memory": "2048M",` as the lowercase m was throwing an error and you can find the error [here](https://gist.github.com/TheCryptek/6e71de750fd4a7e09ebed9ce66296e2d)